### PR TITLE
add a default unhandled encoding for the tallyKeepingFileStreamWriter…

### DIFF
--- a/source/Src/SemanticLogging/Sinks/TallyKeepingFileStreamWriter.cs
+++ b/source/Src/SemanticLogging/Sinks/TallyKeepingFileStreamWriter.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Sinks
         /// </summary>
         /// <param name="stream">The <see cref="FileStream"/> to write to.</param>
         public TallyKeepingFileStreamWriter(FileStream stream)
-            : base(stream)
+            : base(stream, GetEncodingWithFallback())
         {
             this.tally = stream.Length;
         }
@@ -102,6 +102,14 @@ namespace Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Sinks
         {
             base.Write(value);
             this.tally += Encoding.GetByteCount(value);
+        }
+
+        private static Encoding GetEncodingWithFallback()
+        {
+            Encoding encoding = (Encoding)new UTF8Encoding(false).Clone();
+            encoding.EncoderFallback = EncoderFallback.ReplacementFallback;
+            encoding.DecoderFallback = DecoderFallback.ReplacementFallback;
+            return encoding;
         }
     }
 }


### PR DESCRIPTION
…, as when it gets data it can't encode nothing is written until the service is restarted. See: http://blogs.msdn.com/b/kimhamil/archive/2008/11/11/making-a-streamwriter-usable-even-after-given-garbage-characters.aspx